### PR TITLE
fix: Add validation/instructions about Docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ sudo usermod -aG docker `whoami`
 sudo reboot
 ```
 
+- **For Ubuntu 22.04 users:** In our tests, `containerd` had to be downgraded to version 1.6.6 in order to have all features working properly. `sudo apt install containerd.io=1.6.6-1`.
+
 ## Container setup
 
 1. Save (right click, save as) the creation script in home directory (`~`): [create_bbb.sh](create_bbb.sh?raw=1)

--- a/create_bbb.sh
+++ b/create_bbb.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+if ! command -v docker &> /dev/null
+then
+    echo "Docker not found! Required Docker 20 or greater"
+    exit
+fi
+
+DOCKER_VERSION=$(docker version -f "{{.Server.Version}}")
+DOCKER_VERSION_MAJOR=$(echo "$DOCKER_VERSION"| cut -d'.' -f 1)
+
+if [ ! "${DOCKER_VERSION_MAJOR}" -ge 20 ] ; then
+    echo "Invalid Docker version! Required Docker 20 or greater"
+    exit
+fi
+
 NAME=
 DOMAIN=test
 IP=172.17.0.2

--- a/create_bbb.sh
+++ b/create_bbb.sh
@@ -258,7 +258,7 @@ ssh-keyscan -H "$DOCKERIP" >> ~/.ssh/known_hosts
 ssh-keyscan -H "$HOSTNAME" >> ~/.ssh/known_hosts
 # ssh-keyscan -H [hostname],[ip_address] >> ~/.ssh/known_hosts
 
-if [ ! -z $(tail -1 ~/.ssh/config) ] ; then
+if [ ! -z "$(tail -1 ~/.ssh/config)" ] ; then
   echo "" >> ~/.ssh/config
 fi
 


### PR DESCRIPTION
- Adds instructions on README to get all features running on Ubuntu 22
- Adds validation on Docker version
- Tweaks the configs added to `~/.ssh/config` to prevent mess in the file