### PR TITLE
Mount /tmp in container and stop mounting ~/shared and /var/lib/docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ ssh bbb26
 Replace **bbb26** with the {name} param of `create_bbb.sh`
 
 
-That's all, open https://bbb26.test in your browser and enjoy.
+### Use `/tmp` to exchange files
+The directory `/tmp` is shared between the host and the container. So you can use this directory to exchange files between them.
+
+### Start using BigBlueButton
+
+That's all, open https://bbb26.test (or your custom `https://{name}.{domain}`) in your browser and enjoy.
 
 PS: if you see certificate error in your browser, you need to add the CA certificate in it's trusted certificates. Instructions for Chrome and Firefox can be found [here](https://github.com/bigbluebutton/docker-dev/issues/1)
 

--- a/create_bbb.sh
+++ b/create_bbb.sh
@@ -54,11 +54,6 @@ for container_id in $(docker ps -f name=$NAME -q -a); do
     docker rm $container_id;
 done
 
-if [ "$(docker volume ls | grep \docker_in_docker${NAME}$)" ]; then
-    echo "Removing volume docker_in_docker$NAME"
-    sudo docker volume rm docker_in_docker$NAME;
-fi
-
 # Remove entries from ~/.ssh/config
 if [ -f ~/.ssh/config ] ; then
   sed -i '/^Host '"$NAME"'$/,/^$/d' ~/.ssh/config
@@ -143,10 +138,6 @@ else
 fi
 
 cd
-
-#Shared folder to exchange data between local machine and container
-BBB_SHARED_FOLDER=$HOME/$NAME/shared
-mkdir -p $BBB_SHARED_FOLDER
 
 ###Certificate start -->
 mkdir $HOME/$NAME/certs/ -p
@@ -236,7 +227,7 @@ fi
 mkdir -p $HOME/.m2/repository/org/bigbluebutton
 mkdir -p $HOME/.ivy2/local/org.bigbluebutton
 
-docker run -d --name=$NAME --hostname=$HOSTNAME $NETWORKPARAMS -env="container=docker" --env="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" --env="DEBIAN_FRONTEND=noninteractive" -v "/var/run/docker.sock:/var/run/docker.sock:rw" --cap-add="NET_ADMIN" --privileged -v "$HOME/$NAME/certs/:/local/certs:rw" --cgroupns=host -v "$BBB_SRC_FOLDER:/home/bigbluebutton/src:rw" -v "$BBB_SHARED_FOLDER:/home/bigbluebutton/shared:rw" -v "$HOME/.m2/repository/org/bigbluebutton:/home/bigbluebutton/.m2/repository/org/bigbluebutton:rw" -v "$HOME/.ivy2/local/org.bigbluebutton:/home/bigbluebutton/.ivy2/local/org.bigbluebutton:rw" -v docker_in_docker$NAME:/var/lib/docker -t $IMAGE
+docker run -d --name=$NAME --hostname=$HOSTNAME $NETWORKPARAMS -env="container=docker" --env="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" --env="DEBIAN_FRONTEND=noninteractive" -v "/var/run/docker.sock:/docker.sock:rw" --cap-add="NET_ADMIN" --privileged -v "$HOME/$NAME/certs/:/local/certs:rw" --cgroupns=host -v "$BBB_SRC_FOLDER:/home/bigbluebutton/src:rw" -v "/tmp:/tmp:rw" -v "$HOME/.m2/repository/org/bigbluebutton:/home/bigbluebutton/.m2/repository/org/bigbluebutton:rw" -v "$HOME/.ivy2/local/org.bigbluebutton:/home/bigbluebutton/.ivy2/local/org.bigbluebutton:rw" -t $IMAGE
 
 mkdir $HOME/.bbb/ &> /dev/null
 echo "docker exec -u bigbluebutton -w /home/bigbluebutton/ -it $NAME /bin/bash  -l" > $HOME/.bbb/$NAME.sh


### PR DESCRIPTION
Since https://github.com/iMDT/bbb-docker-dev-build/commit/717489615aba8e9bf1e2e2d0fc6f6011fed3c7b0, `docker-ce` are being removed from the bbb-dev container.

Hence some changes on bind-mount of `docker run` was required:

- Add `-v "/tmp:/tmp:rw"`
It is necessary because `bbb-libreoffice-conversion/convert.sh` stores files in `/tmp` of the container, and now the soffice docker will be executed outside of the container, so it was required to mount the host `/tmp` in order to make the same path exists in both sides (host and container).

- Removes `-v "$BBB_SHARED_FOLDER:/home/bigbluebutton/shared:rw"`
Now the host and container will share `/tmp` directory. So it is not necessary to have the `~/shared` to exchange files anymore.

- Removes `-v docker_in_docker$NAME:/var/lib/docker`
Now the container doesn't have Docker installed anymore so this mount became useless

- Tweak `-v "/var/run/docker.sock:/docker.sock:rw"`
For some mysterious reason it was not possible to mount the socket in container `/var/run/docker.sock`.
So it will be mounted in `/docker.sock` and set `DOCKER_HOST=unix:///docker.sock` in `/etc/environment` to make docker know the new path  (https://github.com/iMDT/bbb-docker-dev-build/pull/34).

Closes #9