### PR TITLE
Add param --custom-script to create_bbb.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ Docker **bbb 2.4**
 
 
 Parameters:
-`./create_bbb.sh [--update] [--fork=github_user] [--domain=domain_name] [--ip=ip_address] [--image=docker_image] [--cert=certificate_dir] {name}`
+`./create_bbb.sh [--update] [--fork=github_user] [--domain=domain_name] [--ip=ip_address] [--image=docker_image] [--cert=certificate_dir] [--custom-script=path/script.sh] {name}`
 - {name}: Name of the container (e.g `bbb26`) **(REQUIRED)**
 - --update: check for new image version `--update`
 - --domain: set the host domain (e.g `--domain=test`), default: `test`. BBB URL will be `https://{NAME} + {DOMAIN}`
 - --cert: specify the directory which contains a certificate (`fullchain.pem` and `privkey.pem`) (e.g `--cert=/tmp`) *(if absent a new certificate will be created)*
+- --custom-script: path of a shell script file to be executed immediately when the container is created (useful for setting some personal preferences for configs)
 - --ip: force container IP (e.g `--ip=172.17.0.2`)
 - --fork: Username in Github with bbb Fork `--fork=bigbluebutton`
 - --image: Force an image different than default `--image=imdt/bigbluebutton:2.6.x-develop`

--- a/create_bbb.sh
+++ b/create_bbb.sh
@@ -20,6 +20,7 @@ IP=172.17.0.2
 IMAGE=imdt/bigbluebutton:2.6.x-develop
 GITHUB_USER=
 CERT_DIR=
+CUSTOM_SCRIPT=
 REMOVE_CONTAINER=0
 CONTAINER_IMAGE=
 
@@ -110,6 +111,8 @@ do
         GITHUB_USER=${var#*=}
     elif [[ $var == --cert* ]] ; then
         CERT_DIR=${var#*=}
+    elif [[ $var == --custom-script* ]] ; then
+        CUSTOM_SCRIPT=${var#*=}
     elif [[ $var == --domain* ]] ; then
         DOMAIN=${var#*=}
     fi
@@ -228,6 +231,11 @@ mkdir -p $HOME/.m2/repository/org/bigbluebutton
 mkdir -p $HOME/.ivy2/local/org.bigbluebutton
 
 docker run -d --name=$NAME --hostname=$HOSTNAME $NETWORKPARAMS -env="container=docker" --env="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" --env="DEBIAN_FRONTEND=noninteractive" -v "/var/run/docker.sock:/docker.sock:rw" --cap-add="NET_ADMIN" --privileged -v "$HOME/$NAME/certs/:/local/certs:rw" --cgroupns=host -v "$BBB_SRC_FOLDER:/home/bigbluebutton/src:rw" -v "/tmp:/tmp:rw" -v "$HOME/.m2/repository/org/bigbluebutton:/home/bigbluebutton/.m2/repository/org/bigbluebutton:rw" -v "$HOME/.ivy2/local/org.bigbluebutton:/home/bigbluebutton/.ivy2/local/org.bigbluebutton:rw" -t $IMAGE
+
+if [ $CUSTOM_SCRIPT ] && [ -f $CUSTOM_SCRIPT ] ; then
+    echo "Executing $CUSTOM_SCRIPT on container $NAME"
+    cat $CUSTOM_SCRIPT | docker exec -i $NAME bash
+fi
 
 mkdir $HOME/.bbb/ &> /dev/null
 echo "docker exec -u bigbluebutton -w /home/bigbluebutton/ -it $NAME /bin/bash  -l" > $HOME/.bbb/$NAME.sh


### PR DESCRIPTION
Introduces a new param `--custom-script=script.sh`

It allows the developer to specify a Shell Script to be executed immediately when the container is created!

That's useful for setting some personal preferences for configs. For example, I like to set these configs as default for bbb-html5.

```bash
sudo yq w -i /etc/bigbluebutton/bbb-html5.yml public.app.defaultSettings.application.overrideLocale en
sudo yq w -i /etc/bigbluebutton/bbb-html5.yml public.app.autoJoin false
sudo yq w -i /etc/bigbluebutton/bbb-html5.yml public.app.askForConfirmationOnLeave false
```

It can also be useful to have several scripts where each one creates a different scenario (for testing purposes).