### PR TITLE
Optimize Docker Image Build by Sharing Cache Directories

### DIFF
--- a/create_bbb.sh
+++ b/create_bbb.sh
@@ -266,12 +266,14 @@ if [ $SUBNETNAME != "bridge" ] && [ "$DOCKER_NETWORK_PARAMS" == "" ] ; then
 fi
 
 
-#Create sbt publish folders to map in Docker
-#It will sync the sbt libs in host machine and docker container (useful for backend development)
-mkdir -p $HOME/.m2/repository/org/bigbluebutton
-mkdir -p $HOME/.ivy2/local/org.bigbluebutton
+#Sync cache dirs between host machine and Docker container (to speed up building time)
+mkdir -p $HOME/.m2 #Sbt publish
+mkdir -p $HOME/.ivy2 #Sbt publish
+mkdir -p $HOME/.cache #Maven
+mkdir -p $HOME/.gradle #Gradle
+mkdir -p $HOME/.npm #Npm
 
-docker run -d --name=$NAME --hostname=$HOSTNAME $DOCKER_NETWORK_PARAMS $DOCKER_CUSTOM_PARAMS -env="container=docker" --env="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" --env="DEBIAN_FRONTEND=noninteractive" -v "/var/run/docker.sock:/docker.sock:rw" --cap-add="NET_ADMIN" --privileged -v "$HOME/$NAME/certs/:/local/certs:rw" --cgroupns=host -v "$BBB_SRC_FOLDER:/home/bigbluebutton/src:rw" -v "/tmp:/tmp:rw" -v "$HOME/.m2/repository/org/bigbluebutton:/home/bigbluebutton/.m2/repository/org/bigbluebutton:rw" -v "$HOME/.ivy2/local/org.bigbluebutton:/home/bigbluebutton/.ivy2/local/org.bigbluebutton:rw" -t $IMAGE
+docker run -d --name=$NAME --hostname=$HOSTNAME $DOCKER_NETWORK_PARAMS $DOCKER_CUSTOM_PARAMS -env="container=docker" --env="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" --env="DEBIAN_FRONTEND=noninteractive" -v "/var/run/docker.sock:/docker.sock:rw" --cap-add="NET_ADMIN" --privileged -v "$HOME/$NAME/certs/:/local/certs:rw" --cgroupns=host -v "$BBB_SRC_FOLDER:/home/bigbluebutton/src:rw" -v "/tmp:/tmp:rw" -v "$HOME/.m2:/home/bigbluebutton/.m2:rw" -v "$HOME/.ivy2:/home/bigbluebutton/.ivy2:rw" -v "$HOME/.cache:/home/bigbluebutton/.cache:rw" -v "$HOME/.gradle:/home/bigbluebutton/.gradle:rw" -v "$HOME/.npm:/home/bigbluebutton/.npm:rw" -t $IMAGE
 
 if [ $CUSTOM_SCRIPT ] && [ -f $CUSTOM_SCRIPT ] ; then
     echo "Executing $CUSTOM_SCRIPT on container $NAME"


### PR DESCRIPTION
**Problem:**

Previously, during the Docker image building phase, our process included caching files for the following components: `bbb-common-msg`, `bbb-common-web`, `bbb-web`, and `bbb-html5`. While this approach had its merits, it posed two significant challenges. First, it increased the time required to build a new Docker image, and second, it inflated the size of the resulting image.

**Solution:**

To address these issues, I'm introducing a new approach. In this updated method, the Docker image will no longer contain pre-cached files. Instead, the cache will persist on the host machine. This design choice ensures that, even when recreating the container, the cache files remain intact, as the Docker container always reads the cache from its parent host.

**Cache Directory Sharing:**

We've established directory sharing between the host and the container for specific components, including:

- `$HOME/.m2` (for Sbt publish)
- `$HOME/.ivy2` (for Sbt publish)
- `$HOME/.cache` (for Maven)
- `$HOME/.gradle` (for Gradle)
- `$HOME/.npm` (for Npm)

**Benefits:**

This approach results in several advantages:

1. **Size Reduction:** The Docker image size is reduced from 4.15GB to 3.34GB, contributing to more efficient resource usage.

<table><tr><td>

![image](https://github.com/bigbluebutton/docker-dev/assets/5660191/46ba9f9f-9bcf-4cfa-a12f-3f06b6481185)

</td></tr></table>

2. **Build Time Improvement:** The build time is significantly reduced from 25 minutes to 18 minutes, making the development process more streamlined and productive.

<table><tr><td>

![image](https://github.com/bigbluebutton/docker-dev/assets/5660191/f9631e59-3841-49f2-8581-bcf56f59c2fa)

</td></tr></table>